### PR TITLE
[codex] recover from malformed daemon info

### DIFF
--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -7,7 +7,7 @@ use crate::daemon::server::start_daemon;
 use crate::daemon::startup_lock::StartupLock;
 use crate::daemon::uds::UnixStream;
 use crate::process_utils::{get_start_time, is_alive};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use log::{debug, info, warn};
 use std::env::current_dir;
 use std::io::{ErrorKind, Write};
@@ -53,8 +53,27 @@ pub fn daemon_is_alive(socket: &DaemonSocketPath) -> Result<DaemonStatus> {
         Err(err) if err.kind() == ErrorKind::NotFound => return Ok(DaemonStatus::NotRunning),
         Err(err) => return Err(err.into()),
     };
-    let (pid, start_time, build_id) =
-        parse_info(&content).context("Failed to parse daemon info")?;
+    let (pid, start_time, build_id) = match parse_info(&content) {
+        Some(info) => info,
+        None => {
+            warn!(
+                "Ignoring malformed daemon info file: {}",
+                socket.info_path.display()
+            );
+
+            if let Err(err) = std::fs::remove_file(&socket.info_path) {
+                if err.kind() != ErrorKind::NotFound {
+                    warn!(
+                        "Failed to remove malformed daemon info file {}: {}",
+                        socket.info_path.display(),
+                        err
+                    );
+                }
+            }
+
+            return Ok(DaemonStatus::NotRunning);
+        }
+    };
 
     if !is_alive(pid) {
         return Ok(DaemonStatus::NotRunning);

--- a/tests/cli_daemon.rs
+++ b/tests/cli_daemon.rs
@@ -2,6 +2,7 @@ mod common;
 
 use crate::common::TestEnv;
 use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
 use predicates::str::contains;
 use regex::Regex;
 
@@ -65,4 +66,21 @@ fn test_cli_daemon_lock() {
 
     assert!(proc_0.wait().unwrap().success());
     assert!(proc_1.wait().unwrap().success());
+}
+
+#[test]
+fn test_cli_daemon_start_recovers_from_malformed_info() {
+    let env = TestEnv::new();
+
+    env.foro(&["daemon", "stop"]);
+    env.socket_dir
+        .child("daemon-cmd.sock.info")
+        .write_str("not,a,daemon")
+        .unwrap();
+
+    let mut res = env.foro_cmd(&["daemon", "start"]);
+    res.assert().success().stderr(contains("Daemon started"));
+
+    let res = env.foro_stdout(&["daemon", "ping"]);
+    assert!(res.contains("pong!"));
 }

--- a/tests/cli_format.rs
+++ b/tests/cli_format.rs
@@ -2,6 +2,7 @@ mod common;
 
 use crate::common::{TestEnv, TestEnvBuilder};
 use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
 
 #[test]
 fn test_cli_format_rust_basic() {
@@ -239,4 +240,18 @@ fn test_cli_format_parallel() {
 
     assert!(proc_0.wait().unwrap().success());
     assert!(proc_1.wait().unwrap().success());
+}
+
+#[test]
+fn test_cli_format_recovers_from_malformed_daemon_info() {
+    let env = TestEnv::new_fixture("./tests/fixtures/cli_format_rust/basic/");
+
+    env.foro(&["daemon", "stop"]);
+    env.socket_dir
+        .child("daemon-cmd.sock.info")
+        .write_str("not,a,daemon")
+        .unwrap();
+
+    env.foro(&["format", "./main.rs"]);
+    env.assert_eq("main.rs", "expected.rs");
 }


### PR DESCRIPTION
## Summary
- treat a malformed `daemon-cmd.sock.info` as stale daemon state instead of a fatal parse error
- remove the malformed info file so daemon-based commands can self-heal on the next start
- add CLI regression coverage for both `foro daemon start` and `foro format`

## Root cause
`daemon_is_alive()` returned `Failed to parse daemon info` when `daemon-cmd.sock.info` was corrupted. That error propagated through `daemon start` and `ensure_daemon_running()`, so daemon-based commands could no longer recover by starting a fresh daemon.

## Impact
A broken hidden state file no longer wedges daemon-based commands. `foro daemon start` and `foro format` now recover by treating the daemon as not running and recreating the info file.

Closes #25

## Validation
- `cargo fmt --check`
- `cargo test --test cli_daemon`
- `cargo test --test cli_format test_cli_format_rust_basic`
- `cargo test --test cli_format test_cli_format_recovers_from_malformed_daemon_info`
